### PR TITLE
Fix interaction reply flags in autorole and ticket systems

### DIFF
--- a/utils/autoRole-system/command/autorolelist.js
+++ b/utils/autoRole-system/command/autorolelist.js
@@ -58,7 +58,7 @@ module.exports = {
 						.setFooter({ text: `${language_result.listCommand.embed_footer}`, iconURL: `${variables.getBotFooterIcon()}` })
 						.setColor(color.general.olive)
 						.setThumbnail(variables.getBotFooterIcon());
-					await interaction.reply({ embeds: [embedLog], flag: 64 });
+					await interaction.reply({ embeds: [embedLog], flags: 64 });
 				}
 				else {
 					await noHavePermission(interaction, language_result);

--- a/utils/ticket-system/command/ticketcomponents.js
+++ b/utils/ticket-system/command/ticketcomponents.js
@@ -135,7 +135,7 @@ module.exports = {
 								.setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
 								.setColor(color.general.error)
 								.setThumbnail(variables.getBotFooterIcon());
-							await interaction.reply({ embeds: [embedLog], flag: 64 });
+							await interaction.reply({ embeds: [embedLog], flags: 64 });
 							return;
 						}
 						embedLog
@@ -143,7 +143,7 @@ module.exports = {
 							.setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
 							.setColor(color.general.success)
 							.setThumbnail(variables.getBotFooterIcon());
-						await interaction.reply({ embeds: [embedLog], flag: 64 });
+						await interaction.reply({ embeds: [embedLog], flags: 64 });
 
 					} else {
 						const embedLog = new EmbedBuilder()
@@ -151,7 +151,7 @@ module.exports = {
 							.setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
 							.setColor(color.general.error)
 							.setThumbnail(variables.getBotFooterIcon());
-						await interaction.reply({ embeds: [embedLog], flag: 64 });
+						await interaction.reply({ embeds: [embedLog], flags: 64 });
 					}
 
 

--- a/utils/ticket-system/events/ticketInteraction.js
+++ b/utils/ticket-system/events/ticketInteraction.js
@@ -61,7 +61,7 @@ module.exports = {
           .setColor(color.general.blue)
           .setThumbnail(variables.getBotFooterIcon());
 
-        await interaction.reply({ embeds: [embedLogTwo], flag: 64 });
+        await interaction.reply({ embeds: [embedLogTwo], flags: 64 });
         await initChannel.send({ embeds: [embedLog], components: [row] });
 
         await createTicketMessages(interaction.guild.id, interaction.user.id, title, description, interaction.channel.id, variables);
@@ -105,7 +105,7 @@ module.exports = {
             .setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
             .setColor(color.general.error)
             .setThumbnail(variables.getBotFooterIcon());
-          await interaction.reply({ embeds: [embedLog], flag: 64 });
+          await interaction.reply({ embeds: [embedLog], flags: 64 });
         }
       }
 
@@ -146,7 +146,7 @@ module.exports = {
             .setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
             .setColor(color.general.error)
             .setThumbnail(variables.getBotFooterIcon());
-          await interaction.reply({ embeds: [embedLog], flag: 64 });
+          await interaction.reply({ embeds: [embedLog], flags: 64 });
         }
       }
 
@@ -176,7 +176,7 @@ module.exports = {
           .setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
           .setColor(color.general.olive)
           .setThumbnail(variables.getBotFooterIcon());
-        await initChannel.send({ content: `${interaction.user}`, embeds: [embedLog], flag: 64 });
+        await initChannel.send({ content: `${interaction.user}`, embeds: [embedLog], flags: 64 });
 
         await updateTicketMessages({transcript_id: channel, message_id: message.id}, {where: {guild_id: interaction.guild.id, initAuthorId: interaction.user.id}});
         await interaction.channel.delete();
@@ -195,7 +195,7 @@ module.exports = {
           if (!await checkFeatureSystemDisabled(2)) return await noEnabledFunc(interaction, language_result.noPermission.description_embed_no_features);
           if (!await checkFeaturesIsEnabled(interaction.message.guild.id, 2, variables)) return await noEnabledFunc(interaction, language_result.noPermission.description_embed_no_features);
 
-          await interaction.deferReply({ flag: 64 });
+          await interaction.deferReply({ flags: 64 });
           const category = await interaction.guild.channels.fetch(checkChannelForInteraction.categoryId);
 
           // CONTROLLO SE IL TICKET E' GIA' APERTO 
@@ -208,7 +208,7 @@ module.exports = {
               .setColor(color.general.error)
               .setThumbnail(variables.getBotFooterIcon());
 
-            await interaction.editReply({ embeds: [embedLog], flag: 64 });
+            await interaction.editReply({ embeds: [embedLog], flags: 64 });
             return;
           }
 
@@ -259,7 +259,7 @@ module.exports = {
             .setFooter({ text: `${variables.getBotFooter()}`, iconURL: `${variables.getBotFooterIcon()}` })
             .setColor(color.general.olive)
             .setThumbnail(variables.getBotFooterIcon());
-          await interaction.editReply({ embeds: [embedLog], flag: 64 });
+          await interaction.editReply({ embeds: [embedLog], flags: 64 });
         }
       }
 


### PR DESCRIPTION
This pull request includes multiple changes to correct a typo in the `interaction.reply` and `interaction.editReply` methods across several files in the project. The most important changes are listed below:

Corrections in `interaction.reply` and `interaction.editReply` methods:

* [`utils/autoRole-system/command/autorolelist.js`](diffhunk://#diff-4e2034ef1283e243fa2b0375cef12471600dc36bc5b109d1258fc16b3304ecefL61-R61): Changed `flag` to `flags` in the `interaction.reply` method.
* [`utils/ticket-system/command/ticketcomponents.js`](diffhunk://#diff-bc82692faa05f14fe21536b1dbb9a696574ad559eb8981af02c26fa71c646665L138-R154): Changed `flag` to `flags` in multiple `interaction.reply` methods.
* [`utils/ticket-system/events/ticketInteraction.js`](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL64-R64): Changed `flag` to `flags` in multiple `interaction.reply`, `interaction.deferReply`, and `interaction.editReply` methods. [[1]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL64-R64) [[2]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL108-R108) [[3]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL149-R149) [[4]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL179-R179) [[5]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL198-R198) [[6]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL211-R211) [[7]](diffhunk://#diff-9904ec3cd2c72bfa1b4129fc9f2fb3475000933c1887d5074d92ad25579c0e6fL262-R262)